### PR TITLE
MessageID set to string instead of number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/p2p",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/p2p",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@bsv/authsocket-client": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/p2p",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "publishConfig": {
     "access": "public"
   },

--- a/src/MessageBoxClient.ts
+++ b/src/MessageBoxClient.ts
@@ -6,7 +6,7 @@ import { Logger } from './Utils/logger.js'
  * Defines the structure of a PeerMessage
  */
 export interface PeerMessage {
-  messageId: number
+  messageId: string
   body: string
   sender: string
   created_at: string

--- a/src/PeerPayClient.ts
+++ b/src/PeerPayClient.ts
@@ -38,7 +38,7 @@ export interface PaymentToken {
  * Represents an incoming payment received via MessageBox.
  */
 export interface IncomingPayment {
-  messageId: number
+  messageId: string
   sender: string
   token: PaymentToken
 }
@@ -256,7 +256,7 @@ export class PeerPayClient extends MessageBoxClient {
       Logger.log(`[PP CLIENT] Payment internalized successfully: ${JSON.stringify(paymentResult, null, 2)}`)
       Logger.log(`[PP CLIENT] Acknowledging payment with messageId: ${payment.messageId}`)
 
-      await this.acknowledgeMessage({ messageIds: [String(payment.messageId)] })
+      await this.acknowledgeMessage({ messageIds: [payment.messageId] })
 
       return { payment, paymentResult }
     } catch (error) {
@@ -287,7 +287,7 @@ export class PeerPayClient extends MessageBoxClient {
           Logger.warn('[PP CLIENT] Warning: authFetch is undefined! Ensure PeerPayClient is initialized correctly.');
         }
         Logger.log(`[PP CLIENT] authFetch instance:`, this.authFetch);
-        const response = await this.acknowledgeMessage({ messageIds: [String(payment.messageId)] });
+        const response = await this.acknowledgeMessage({ messageIds: [payment.messageId] });
         Logger.log(`[PP CLIENT] Acknowledgment response: ${response}`);
       } catch (error: any) {
         if (error.message.includes('401')) {
@@ -314,7 +314,7 @@ export class PeerPayClient extends MessageBoxClient {
 
     try {
       Logger.log(`[PP CLIENT] Acknowledging message ${payment.messageId} after refunding...`);
-      await this.acknowledgeMessage({ messageIds: [String(payment.messageId)] });
+      await this.acknowledgeMessage({ messageIds: [payment.messageId] });
       Logger.log(`[PP CLIENT] Acknowledgment after refund successful.`);
     } catch (error: any) {
       Logger.error(`[PP CLIENT] Error acknowledging message after refund: ${error.message}`);

--- a/src/__tests/PeerPayClientUnit.test.ts
+++ b/src/__tests/PeerPayClientUnit.test.ts
@@ -163,7 +163,7 @@ describe('PeerPayClient Unit Tests', () => {
       jest.spyOn(peerPayClient, 'acknowledgeMessage').mockResolvedValue('acknowledged')
 
       const payment = {
-        messageId: 123,
+        messageId: '123',
         sender: 'senderKey',
         token: {
           customInstructions: { derivationPrefix: 'prefix', derivationSuffix: 'suffix' },
@@ -187,7 +187,7 @@ describe('PeerPayClient Unit Tests', () => {
       jest.spyOn(peerPayClient, 'acknowledgeMessage').mockResolvedValue('acknowledged');
 
       const payment = {
-        messageId: 123,
+        messageId: '123',
         sender: 'senderKey',
         token: {
           customInstructions: { derivationPrefix: 'prefix', derivationSuffix: 'suffix' },
@@ -214,7 +214,7 @@ describe('PeerPayClient Unit Tests', () => {
     it('should return parsed payment messages', async () => {
       jest.spyOn(peerPayClient, 'listMessages').mockResolvedValue([
         {
-          messageId: 1,
+          messageId: '1',
           sender: 'sender1',
           created_at: '2025-03-05T12:00:00Z',
           updated_at: '2025-03-05T12:05:00Z',
@@ -225,7 +225,7 @@ describe('PeerPayClient Unit Tests', () => {
           })
         },
         {
-          messageId: 2,
+          messageId: '2',
           sender: 'sender2',
           created_at: '2025-03-05T12:10:00Z',
           updated_at: '2025-03-05T12:15:00Z',


### PR DESCRIPTION
To fixe the bug of a type mismatch, MessageID was set to string type in PeerPay and MessageBox so the type remains consistent throughout.