### PR TITLE
Improve reliability and logging in PeerPay and MessageBox clients

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/p2p",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/p2p",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@bsv/authsocket-client": "^1.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/p2p",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/p2p",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@bsv/authsocket-client": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/p2p",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "publishConfig": {
     "access": "public"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/p2p",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "publishConfig": {
     "access": "public"
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,7 +37,7 @@ export interface MessageBoxClientOptions {
  */
 export interface PeerMessage {
   messageId: string
-  body: string
+  body: string | Record<string, any>
   sender: string
   created_at: string
   updated_at: string


### PR DESCRIPTION

This PR introduces several important updates to ensure the @bsv/p2p package works reliably across environments (especially in Metanet Mobile), and provides better diagnostics and fallback behavior for developers and users.

## Key Improvements
### 1. WebSocket Fallback to HTTP (sendLiveMessage → sendMessage)
- MessageBoxClient.sendLiveMessage was updated to fallback to HTTP (sendMessage) automatically if WebSocket is disconnected or times out.

- Similarly, PeerPayClient.sendLivePayment now wraps sendLiveMessage in a try/catch block and falls back to sendMessage on any failure.

- This ensures mobile and network-restricted environments can still send payments without failure.

### 2. Fix [object Object] JSON errors
- Improved JSON parsing and logging by adding a safeParse() utility:

     - Prevents cryptic "[object Object]" is not valid JSON errors.

     - Any message that can't be parsed is safely defaulted to an empty object, and a clear warning is logged.

- Added this logic in all message-handling code paths (e.g. listenForLiveMessages, listMessages, etc).

### 3. Improved Logging and Stack Traces
- Replaced generic console.log calls with formatted logs including:

     - Logger.log, Logger.warn, and Logger.error tags.

     - JSON-stringified objects with indentation.

     - Optional source stack trace to aid debugging.

### 4. WebSocket Initialization Reliability
- Fixed an issue where initializeConnection() could silently fail due to WebSocket authentication timeouts.

     - Clear error messages when initialization fails.

### 5. Improved Type Safety and Defaults
- Added stronger type guards around parsed response objects and message payloads.

- Prevented undefined or malformed data from crashing internal flows.

### Tested In:
- Metanet Desktop

- Metanet Mobile (Android)

- Local and ngrok tunnels